### PR TITLE
build_falter: store images in central directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+firmwares/

--- a/build_falter
+++ b/build_falter
@@ -66,10 +66,15 @@ function start_build {
 	make image PROFILE="$profile" PACKAGES="$PACKAGE_SET"
 	echo "finished"
     done
+    # move binaries into central firmware-dir
+    rsync -a --remove-source-files bin/targets/* ../../firmwares/
 
     cd ..
 }
 
+# remove artifacts of last build
+mkdir -p firmwares
+rm -rf firmwares/*
 mkdir -p build
 rm -rf build/*
 cd build


### PR DESCRIPTION
With this commit, the firmware images from all image-builders
will be stored in a central directory 'firmwares' in the root-
directory.