### PR TITLE
build_falter: fix repo-url to new structure

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -72,7 +72,11 @@ function start_build {
     echo "injecting repo line: $REPO"
     echo "$REPO" >> repositories.conf
 
-    generate_embedded_files $IMAGE_BUILDER_URL
+    echo "loading package-feed key..."
+    local URL=$(echo $FALTER_REPO_BASE | cut -d' ' -f3)
+    curl "$URL/key-build.pub" > keys/3169149e744f86a1
+
+    generate_embedded_files
     for profile in $(make info | grep ":$" | grep "Default" -A1000 | cut -d: -f1 | grep -v "Default"); do
         echo "start building $profile..."
         make image PROFILE="$profile" PACKAGES="$PACKAGE_SET" FILES="../../embedded-files/"


### PR DESCRIPTION
The structure of package feed changed. Now, the instruction
sets reside directly und the version-directory.