### PR TITLE
build_falter: enable building specific subtargets only

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,28 @@ This script packages falter-firmware from openwrt-imagebuilder and falter-feed. 
 
 ## utilisation
 
-The script takes three positional arguments.
+The script takes four positional arguments.
 
 ```
-./build [packageset] <release> <target>
+./build_falter [packageset] <release> <target> <subtarget>
 ```
 
-The first argument is mandatory, the latter optional.
+The first argument is mandatory, the latter ones optional.
 If you just give a packageset, all releases and all targets get built.
 
 If you give packageset, release and no target, it will generate all targets of that certain release and so on.
+
+`release` takes currently two values: `19.07` and `snapshot`. 
+
+After the buildprocess finished, you will find the images in `firmwares/`.
+
+## build your own image
+
+Lets assume you'd like to build a stable-release-tunneldigger-image for your GL-AR150 router. To achieve
+that, you should invoke the buildscript in that way:
+
+```
+./build_falter packageset/tunneldigger.txt 19.07 ath79 generic
+```
+
+That will assemble the target `ath79-generic`. We might add a way to build single targets in the future.

--- a/build_falter
+++ b/build_falter
@@ -84,6 +84,7 @@ cd build
 if [ $# -gt 0 ]; then
 	CONF_RELEASE="$1"
 	CONF_TARGET="$2"
+	CONF_SUBTARGET="$3"
 fi
 
 
@@ -112,13 +113,18 @@ elif [ -z "$CONF_TARGET" ]; then
 else
 	# there was given a release and a target
 	RELEASE_LINK=$(echo "$RELEASES" | tr ' ' '\n' | grep "$CONF_RELEASE" | tail -n 1)
-	echo $(fetch_subdirs "$RELEASE_LINK$CONF_TARGET/")
+	# if there was defined a subtarget, only build that.
+	if [ -n "$CONF_SUBTARGET" ]; then
+		# build directly that subtarget
+		TARGET_LIST="$RELEASE_LINK$CONF_TARGET/$CONF_SUBTARGET/"
+		IMAGEBUILDER=$(fetch_subdirs "$TARGET_LIST" | grep imagebuilder)
+		start_build "$TARGET_LIST$IMAGEBUILDER"
+		exit
+	fi
+	# otherwise, fetch all subtargets and build them one after another.
 		for subtarget in $(fetch_subdirs "$RELEASE_LINK$CONF_TARGET/"); do
 			imagebuilder=$(fetch_subdirs "$RELEASE_LINK$CONF_TARGET/$subtarget" | grep imagebuilder)
 		    start_build "$RELEASE_LINK$CONF_TARGET/$subtarget$imagebuilder"
 	    done
 	exit
 fi
-
-
-


### PR DESCRIPTION
This PR enables build_falter to build one specific subtarget only. This solves #7.