### PR TITLE
build_falter: match profiles correctly

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -78,7 +78,7 @@ function start_build {
 
     generate_embedded_files
     if [ -z $2 ]; then
-      for profile in $(make info | grep ":$" | grep "Default" -A1000 | cut -d: -f1 | grep -v "Default"); do
+      for profile in $(make info | grep ":$" | cut -d: -f1 | grep -v "Available Profiles" | grep -v "Default"); do
           echo "start building $profile..."
           make image PROFILE="$profile" PACKAGES="$PACKAGE_SET" FILES="../../embedded-files/"
           echo "finished"


### PR DESCRIPTION
Due to wrong detection of the profiles contained in the
imagebuilder, some targets did not build. That was the
case for i.e. x86, bcm27xx, and some more.
This commit gives a corrected recipe for fetching those
profiles. It fixes #12.

Signed-off-by: Martin Hübner <martin.hubner@web.de>