### PR TITLE
build_falter: add version-string

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -36,6 +36,10 @@ function generate_embedded_files {
     # call scripts to generate dynamic data in embedded files
     local TARGET=$(echo $IMAGE_BUILDER_URL | cut -d'/' -f 7)
     local SUBTARGET=$(echo $IMAGE_BUILDER_URL | cut -d'/' -f 8)
+    #if Version-string is not empty, concatenate it with VERSION
+    if [ $VERSIONSTR ]; then
+      VERSION+="-$VERSIONSTR"
+    fi
     ../../scripts/01-generate_banner.sh $VERSION $NICKNAME $TARGET $SUBTARGET
     ../../scripts/02-generate-release-file.sh $VERSION
     ../../scripts/03-luci-footer.sh $VERSION $NICKNAME $TARGET $SUBTARGET

--- a/buildconfig.conf
+++ b/buildconfig.conf
@@ -1,2 +1,4 @@
 VERSION='1.1.0'
 NICKNAME='falter'
+# concatenate string to version-name. Leave empty for release
+VERSIONSTR='beta5'


### PR DESCRIPTION
Defines a variable $VERSIONSTR in buildconfig.conf. That
enables us to mark releases as i.e. beta or rc. Leave
empty for release.
This fixes #15

Signed-off-by: Martin Hübner <martin.hubner@web.de>