### PR TITLE
footer: optimize script to pull the currect luci footer

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -45,7 +45,7 @@ function generate_embedded_files {
     eval $(curl https://raw.githubusercontent.com/Freifunk-Spalter/packages/${FALTERBRANCH}/packages/falter-common/files-common/etc/freifunk_release)
 
     ../../scripts/01-generate_banner.sh $FREIFUNK_RELEASE $NICKNAME $TARGET $SUBTARGET
-    ../../scripts/03-luci-footer.sh $FREIFUNK_RELEASE $NICKNAME $TARGET $SUBTARGET
+    ../../scripts/03-luci-footer.sh $FREIFUNK_RELEASE $NICKNAME $TARGET $SUBTARGET $FREIFUNK_OPENWRT_BASE
 }
 
 function start_build {

--- a/scripts/03-luci-footer.sh
+++ b/scripts/03-luci-footer.sh
@@ -2,10 +2,11 @@ VERSION="$1"
 NICKNAME="$2"
 TARGET="$3"
 SUBTARGET="$4"
+OPENWRT_BASE="$5"
 # get current path of script. Thus we can call the script from everywhere.
 SCRIPTPATH=$(dirname $(readlink -f "$0"))
 
-SRCFOOTER="https://raw.githubusercontent.com/openwrt/luci/master/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/footer.htm"
+SRCFOOTER="https://raw.githubusercontent.com/openwrt/luci/${OPENWRT_BASE}/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/footer.htm"
 FOOTERDIR="$SCRIPTPATH/../embedded-files/usr/lib/lua/luci/view/themes/bootstrap/"
 mkdir -p $FOOTERDIR
 


### PR DESCRIPTION
Using the stored value of FREIFUNK_OPENWRT_BASE, the correct
footer.htm file will be downloaded.  FREIFUNK_OPENWRT_BASE is
found in the freifunk_release file in the falter-common package.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>