### PR TITLE
build_falter: add openwrt-release 19.07.5

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -5,6 +5,7 @@ source buildconfig.conf
 
 RELEASES="
     https://downloads.openwrt.org/releases/19.07.4/targets/
+    https://downloads.openwrt.org/releases/19.07.5/targets/
     https://downloads.openwrt.org/snapshots/targets/"
 
 FALTER_REPO_BASE="src/gz openwrt_falter http://download-master.berlin.freifunk.net/falter-feed"


### PR DESCRIPTION
This commit adds the new OpenWrt-release 19.07.5 into builter-script.

Signed-off-by: Martin Hübner <martin.hubner@web.de>