### PR TITLE
packagesets: add luci-app for opkg

### DIFF
--- a/packageset/19.07/backbone.txt
+++ b/packageset/19.07/backbone.txt
@@ -39,6 +39,7 @@ px5g-mbedtls
 libustream-mbedtls
 luci-mod-falter
 luci-app-olsr
+luci-app-opkg
 luci-app-olsr-services
 luci-app-falter-owm
 luci-app-falter-owm-ant
@@ -50,6 +51,8 @@ luci-i18n-base-de
 luci-i18n-base-en
 luci-i18n-olsr-de
 luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
 

--- a/packageset/19.07/notunnel.txt
+++ b/packageset/19.07/notunnel.txt
@@ -46,6 +46,7 @@ libustream-mbedtls
 luci-app-ffwizard-falter
 luci-mod-falter
 luci-app-olsr
+luci-app-opkg
 luci-app-firewall
 luci-app-olsr-services
 luci-app-falter-owm
@@ -60,6 +61,8 @@ luci-i18n-firewall-de
 luci-i18n-firewall-en
 luci-i18n-olsr-de
 luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
 

--- a/packageset/19.07/tunneldigger.txt
+++ b/packageset/19.07/tunneldigger.txt
@@ -46,6 +46,7 @@ uhttpd-mod-ubus
 luci-app-ffwizard-falter
 luci-mod-falter
 luci-app-olsr
+luci-app-opkg
 luci-app-firewall
 luci-app-olsr-services
 luci-app-falter-owm
@@ -60,6 +61,8 @@ luci-i18n-firewall-de
 luci-i18n-firewall-en
 luci-i18n-olsr-de
 luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
 

--- a/packageset/snapshot/backbone.txt
+++ b/packageset/snapshot/backbone.txt
@@ -37,6 +37,7 @@ uhttpd-mod-ubus
 luci-ssl
 luci-mod-falter
 luci-app-olsr
+luci-app-opkg
 luci-app-olsr-services
 luci-app-falter-owm
 luci-app-falter-owm-ant
@@ -48,6 +49,8 @@ luci-i18n-base-de
 luci-i18n-base-en
 luci-i18n-olsr-de
 luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
 

--- a/packageset/snapshot/notunnel.txt
+++ b/packageset/snapshot/notunnel.txt
@@ -44,6 +44,7 @@ luci-ssl
 luci-app-ffwizard-falter
 luci-mod-falter
 luci-app-olsr
+luci-app-opkg
 luci-app-firewall
 luci-app-olsr-services
 luci-app-falter-owm
@@ -58,6 +59,8 @@ luci-i18n-firewall-de
 luci-i18n-firewall-en
 luci-i18n-olsr-de
 luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
 

--- a/packageset/snapshot/tunneldigger.txt
+++ b/packageset/snapshot/tunneldigger.txt
@@ -44,6 +44,7 @@ luci-ssl
 luci-app-ffwizard-falter
 luci-mod-falter
 luci-app-olsr
+luci-app-opkg
 luci-app-firewall
 luci-app-olsr-services
 luci-app-falter-owm
@@ -58,6 +59,8 @@ luci-i18n-firewall-de
 luci-i18n-firewall-en
 luci-i18n-olsr-de
 luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
 


### PR DESCRIPTION
In luci-menu, the entry for 'software' was missing. This was
due a missing package for that menu.

This fixes https://github.com/Freifunk-Spalter/packages/issues/99

Signed-off-by: Martin Hübner <martin.hubner@web.de>