### PR TITLE
packagelists: don't remove ppp-related packages

### DIFF
--- a/packageset/19.07/backbone.txt
+++ b/packageset/19.07/backbone.txt
@@ -1,5 +1,3 @@
--ppp
--ppp-mod-pppoe
 -wpad-mini
 #wpad
 
@@ -45,6 +43,7 @@ luci-app-falter-owm
 luci-app-falter-owm-ant
 luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
+luci-proto-ppp
 luci-theme-bootstrap
 # GUI addon
 luci-i18n-base-de

--- a/packageset/19.07/notunnel.txt
+++ b/packageset/19.07/notunnel.txt
@@ -1,5 +1,3 @@
--ppp
--ppp-mod-pppoe
 -wpad-mini
 #wpad
 
@@ -53,6 +51,7 @@ luci-app-falter-owm
 luci-app-falter-owm-ant
 luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
+luci-proto-ppp
 luci-theme-bootstrap
 # GUI addon
 luci-i18n-base-de

--- a/packageset/19.07/tunneldigger.txt
+++ b/packageset/19.07/tunneldigger.txt
@@ -1,5 +1,3 @@
--ppp
--ppp-mod-pppoe
 #-wpad-mini
 #wpad
 
@@ -53,6 +51,7 @@ luci-app-falter-owm
 luci-app-falter-owm-ant
 luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
+luci-proto-ppp
 luci-theme-bootstrap
 # GUI addon
 luci-i18n-base-de

--- a/packageset/snapshot/backbone.txt
+++ b/packageset/snapshot/backbone.txt
@@ -1,5 +1,3 @@
--ppp
--ppp-mod-pppoe
 -wpad-mini
 #wpad
 
@@ -43,6 +41,7 @@ luci-app-falter-owm
 luci-app-falter-owm-ant
 luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
+luci-proto-ppp
 luci-theme-bootstrap
 # GUI addon
 luci-i18n-base-de

--- a/packageset/snapshot/notunnel.txt
+++ b/packageset/snapshot/notunnel.txt
@@ -1,5 +1,3 @@
--ppp
--ppp-mod-pppoe
 -wpad-mini
 #wpad
 
@@ -51,6 +49,7 @@ luci-app-falter-owm
 luci-app-falter-owm-ant
 luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
+luci-proto-ppp
 luci-theme-bootstrap
 # GUI addon
 luci-i18n-base-de

--- a/packageset/snapshot/tunneldigger.txt
+++ b/packageset/snapshot/tunneldigger.txt
@@ -1,5 +1,3 @@
--ppp
--ppp-mod-pppoe
 #-wpad-mini
 #wpad
 
@@ -51,6 +49,7 @@ luci-app-falter-owm
 luci-app-falter-owm-ant
 luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
+luci-proto-ppp
 luci-theme-bootstrap
 # GUI addon
 luci-i18n-base-de


### PR DESCRIPTION
The removal of dsl-related packages was presumeably introduced
2014 to save space on 4MB-Devices. As Falter does not care for
those, we may readd them.

Have a look at: https://github.com/Freifunk-Spalter/packages/pull/92#issuecomment-744026824

Before merging this, we should have some further discussion on the
standard WAN-Interface (on DSL-Modem or LAN1)