### PR TITLE
build_falter: include falter-feed into images

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -52,6 +52,8 @@ function generate_embedded_files {
 
     ../../scripts/01-generate_banner.sh $FREIFUNK_RELEASE $NICKNAME $TARGET $SUBTARGET
     ../../scripts/03-luci-footer.sh $FREIFUNK_RELEASE $NICKNAME $TARGET $SUBTARGET $FREIFUNK_OPENWRT_BASE
+    export FALTER_REPO_BASE # export repo line to inject into images. contains whitespace...
+    ../../scripts/04-include-falter-feed.sh
 }
 
 function start_build {

--- a/scripts/04-include-falter-feed.sh
+++ b/scripts/04-include-falter-feed.sh
@@ -1,0 +1,20 @@
+# inject the feed line into the file customfeed.conf and
+# include that file via embedded-files into images.
+
+# get current path of script. Thus we can call the script from everywhere.
+SCRIPTPATH=$(dirname $(readlink -f "$0"))
+
+mkdir -p "$SCRIPTPATH/../embedded-files/etc/opkg/keys"
+
+# load package-key and post it to dir. keyname is keys fingerprint.
+URL="https://buildbot.berlin.freifunk.net/buildbot/feed/packagefeed_master.pub"
+curl "$URL" > "$SCRIPTPATH/../embedded-files/etc/opkg/keys/61a078a38408e710"
+
+# We inherited $FALTER_REPO_BASE from caller whom exported it.
+printf \
+"
+# add your custom package feeds here
+#
+# src/gz example_feed_name http://www.example.com/path/to/files
+$FALTER_REPO_BASE
+" > "$SCRIPTPATH/../embedded-files/etc/opkg/customfeeds.conf"


### PR DESCRIPTION
The imagsbuilder doesn't include the build-time falter-feed into
the images by itself. This commit enables that, by generating a
customfeeds.conf-file for opkg and include it into the images via
the embedded_files directory.

This commit fixes https://github.com/Freifunk-Spalter/packages/issues/97

Signed-off-by: Martin Hübner <martin.hubner@web.de>