### PR TITLE
build_falter: add openwrt 19.07.6

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -4,8 +4,8 @@
 source buildconfig.conf
 
 RELEASES="
-    https://downloads.openwrt.org/releases/19.07.4/targets/
     https://downloads.openwrt.org/releases/19.07.5/targets/
+    https://downloads.openwrt.org/releases/19.07.6/targets/
     https://downloads.openwrt.org/snapshots/targets/"
 
 FALTER_REPO_BASE="src/gz openwrt_falter http://download-master.berlin.freifunk.net/falter-feed"


### PR DESCRIPTION
This adds the link to the 19.07.6 imagebuilders

Signed-off-by: Martin Hübner <martin.hubner@web.de>