### PR TITLE
packagesets: add transaltion packages

### DIFF
--- a/packageset/19.07/backbone.txt
+++ b/packageset/19.07/backbone.txt
@@ -45,7 +45,8 @@ luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
 luci-proto-ppp
 luci-theme-bootstrap
-# GUI addon
+
+# GUI translation stuff
 luci-i18n-base-de
 luci-i18n-base-en
 luci-i18n-olsr-de
@@ -54,6 +55,12 @@ luci-i18n-opkg-de
 luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
 
 # OLSR
 olsrd

--- a/packageset/19.07/notunnel.txt
+++ b/packageset/19.07/notunnel.txt
@@ -53,7 +53,8 @@ luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
 luci-proto-ppp
 luci-theme-bootstrap
-# GUI addon
+
+# GUI translation stuff
 luci-i18n-base-de
 luci-i18n-base-en
 luci-i18n-firewall-de
@@ -64,6 +65,12 @@ luci-i18n-opkg-de
 luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
 
 # OLSR
 olsrd

--- a/packageset/19.07/tunneldigger.txt
+++ b/packageset/19.07/tunneldigger.txt
@@ -53,7 +53,8 @@ luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
 luci-proto-ppp
 luci-theme-bootstrap
-# GUI addon
+
+# GUI transaltion stuff
 luci-i18n-base-de
 luci-i18n-base-en
 luci-i18n-firewall-de
@@ -64,6 +65,12 @@ luci-i18n-opkg-de
 luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
 
 # OLSR
 olsrd

--- a/packageset/snapshot/backbone.txt
+++ b/packageset/snapshot/backbone.txt
@@ -43,7 +43,8 @@ luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
 luci-proto-ppp
 luci-theme-bootstrap
-# GUI addon
+
+# GUI transalation stuff
 luci-i18n-base-de
 luci-i18n-base-en
 luci-i18n-olsr-de
@@ -52,6 +53,12 @@ luci-i18n-opkg-de
 luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
 
 # OLSR
 olsrd

--- a/packageset/snapshot/notunnel.txt
+++ b/packageset/snapshot/notunnel.txt
@@ -51,7 +51,8 @@ luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
 luci-proto-ppp
 luci-theme-bootstrap
-# GUI addon
+
+# GUI translation stuff
 luci-i18n-base-de
 luci-i18n-base-en
 luci-i18n-firewall-de
@@ -62,6 +63,12 @@ luci-i18n-opkg-de
 luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
 
 # OLSR
 olsrd

--- a/packageset/snapshot/tunneldigger.txt
+++ b/packageset/snapshot/tunneldigger.txt
@@ -51,7 +51,8 @@ luci-app-falter-owm-cmd
 luci-app-falter-owm-gui
 luci-proto-ppp
 luci-theme-bootstrap
-# GUI addon
+
+# GUI transaltion stuff
 luci-i18n-base-de
 luci-i18n-base-en
 luci-i18n-firewall-de
@@ -62,6 +63,12 @@ luci-i18n-opkg-de
 luci-i18n-opkg-en
 luci-i18n-statistics-de
 luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
 
 # OLSR
 olsrd


### PR DESCRIPTION
This commit adds the translation-packages for ffwizard,
wireless settings and policy-routing page to the packagelists.
Thus falter can display them in English and German.

This is related to the Pull-Request https://github.com/Freifunk-Spalter/packages/pull/113.
It helps solving Issue https://github.com/Freifunk-Spalter/packages/issues/110