### PR TITLE
packagelists: reduce size of images

### DIFF
--- a/packageset/19.07/backbone.txt
+++ b/packageset/19.07/backbone.txt
@@ -75,6 +75,7 @@ kmod-ipip
 # BATMAN
 kmod-batman-adv
 alfred
+-batctl-tiny
 batctl-full
 
 # Statistics

--- a/packageset/19.07/backbone.txt
+++ b/packageset/19.07/backbone.txt
@@ -20,7 +20,7 @@ falter-common
 falter-common-olsr
 
 # Utils
-tcpdump
+tcpdump-mini
 mtr
 ip
 iperf

--- a/packageset/19.07/notunnel.txt
+++ b/packageset/19.07/notunnel.txt
@@ -26,7 +26,7 @@ qos-scripts
 firewall
 iwinfo
 libiwinfo-lua
-tcpdump
+tcpdump-mini
 
 # falter Common
 falter-common

--- a/packageset/19.07/notunnel.txt
+++ b/packageset/19.07/notunnel.txt
@@ -85,6 +85,7 @@ kmod-ipip
 # BATMAN
 kmod-batman-adv
 alfred
+-batctl-tiny
 batctl-full
 
 # Uplink

--- a/packageset/19.07/tunneldigger.txt
+++ b/packageset/19.07/tunneldigger.txt
@@ -84,6 +84,7 @@ kmod-ipip
 # BATMAN
 kmod-batman-adv
 alfred
+-batctl-tiny
 batctl-full
 
 # Uplink

--- a/packageset/19.07/tunneldigger.txt
+++ b/packageset/19.07/tunneldigger.txt
@@ -18,7 +18,6 @@ falter-profiles
 mtr
 ip
 iperf
-iperf3-ssl
 tmux
 vnstat
 ethtool
@@ -28,7 +27,7 @@ qos-scripts
 firewall
 iwinfo
 libiwinfo-lua
-tcpdump
+tcpdump-mini
 
 # falter Common
 falter-common

--- a/packageset/snapshot/backbone.txt
+++ b/packageset/snapshot/backbone.txt
@@ -73,6 +73,7 @@ kmod-ipip
 # BATMAN
 kmod-batman-adv
 alfred
+-batctl-tiny
 batctl-full
 
 # Statistics

--- a/packageset/snapshot/backbone.txt
+++ b/packageset/snapshot/backbone.txt
@@ -19,7 +19,7 @@ falter-common
 falter-common-olsr
 
 # Utils
-tcpdump
+tcpdump-mini
 mtr
 ip
 iperf

--- a/packageset/snapshot/notunnel.txt
+++ b/packageset/snapshot/notunnel.txt
@@ -83,6 +83,7 @@ kmod-ipip
 # BATMAN
 kmod-batman-adv
 alfred
+-batctl-tiny
 batctl-full
 
 # Uplink

--- a/packageset/snapshot/notunnel.txt
+++ b/packageset/snapshot/notunnel.txt
@@ -25,7 +25,7 @@ qos-scripts
 firewall
 iwinfo
 libiwinfo-lua
-tcpdump
+tcpdump-mini
 
 # falter Common
 falter-common

--- a/packageset/snapshot/tunneldigger.txt
+++ b/packageset/snapshot/tunneldigger.txt
@@ -17,7 +17,6 @@ falter-profiles
 mtr
 ip
 iperf
-iperf3-ssl
 tmux
 vnstat
 ethtool
@@ -27,7 +26,7 @@ qos-scripts
 firewall
 iwinfo
 libiwinfo-lua
-tcpdump
+tcpdump-mini
 
 # falter Common
 falter-common

--- a/packageset/snapshot/tunneldigger.txt
+++ b/packageset/snapshot/tunneldigger.txt
@@ -82,6 +82,7 @@ kmod-ipip
 # BATMAN
 kmod-batman-adv
 alfred
+-batctl-tiny
 batctl-full
 
 # Uplink


### PR DESCRIPTION
replace tcpdump with tcpdump-mini and remove iperf3-ssl

explicitly do not install batctl-tiny since we are installing -full

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>