### PR TITLE
packagesets: reorder the batman packages

### DIFF
--- a/packageset/19.07/backbone.txt
+++ b/packageset/19.07/backbone.txt
@@ -73,10 +73,10 @@ olsrd-mod-watchdog
 kmod-ipip
 
 # BATMAN
+batctl-full
+-batctl-tiny
 kmod-batman-adv
 alfred
--batctl-tiny
-batctl-full
 
 # Statistics
 luci-app-statistics

--- a/packageset/19.07/notunnel.txt
+++ b/packageset/19.07/notunnel.txt
@@ -83,10 +83,10 @@ olsrd-mod-watchdog
 kmod-ipip
 
 # BATMAN
+batctl-full
+-batctl-tiny
 kmod-batman-adv
 alfred
--batctl-tiny
-batctl-full
 
 # Uplink
 falter-berlin-uplink-notunnel

--- a/packageset/19.07/tunneldigger.txt
+++ b/packageset/19.07/tunneldigger.txt
@@ -82,10 +82,10 @@ olsrd-mod-watchdog
 kmod-ipip
 
 # BATMAN
+batctl-full
+-batctl-tiny
 kmod-batman-adv
 alfred
--batctl-tiny
-batctl-full
 
 # Uplink
 falter-berlin-uplink-tunnelberlin

--- a/packageset/snapshot/backbone.txt
+++ b/packageset/snapshot/backbone.txt
@@ -71,10 +71,10 @@ olsrd-mod-watchdog
 kmod-ipip
 
 # BATMAN
+batctl-full
+-batctl-tiny
 kmod-batman-adv
 alfred
--batctl-tiny
-batctl-full
 
 # Statistics
 luci-app-statistics

--- a/packageset/snapshot/notunnel.txt
+++ b/packageset/snapshot/notunnel.txt
@@ -81,10 +81,10 @@ olsrd-mod-watchdog
 kmod-ipip
 
 # BATMAN
+batctl-full
+-batctl-tiny
 kmod-batman-adv
 alfred
--batctl-tiny
-batctl-full
 
 # Uplink
 falter-berlin-uplink-notunnel

--- a/packageset/snapshot/tunneldigger.txt
+++ b/packageset/snapshot/tunneldigger.txt
@@ -80,10 +80,10 @@ olsrd-mod-watchdog
 kmod-ipip
 
 # BATMAN
+batctl-full
+-batctl-tiny
 kmod-batman-adv
 alfred
--batctl-tiny
-batctl-full
 
 # Uplink
 falter-berlin-uplink-tunnelberlin


### PR DESCRIPTION
reorder the batman packages so that batctl-full is listed before
kmod-batman-adv.  Otherwise both batctl-full and batctl-tiny will be
installed.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>