### PR TITLE
build_falter: implement dependency check

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -20,6 +20,16 @@ fi
 
 FREIFUNK_RELEASE=""
 
+# check for dependencies.
+SCRIPT_DEPENDS="awk curl gawk grep git gettext python3 rsync sed unzip wget"
+for DEP in $SCRIPT_DEPENDS; do
+  type "$DEP" > /dev/null
+  if [ $? != 0 ]; then
+    echo "$DEP is not installed, but needed for this script."
+    exit 1
+  fi
+done
+
 
 function read_packageset {
 	local PACKAGE_SET_PATH=$1


### PR DESCRIPTION
The script uses several tools that aren't shipped with standard
distributions. Therefor this script adds a dependency check.

Signed-off-by: Martin Hübner <martin.hubner@web.de>