### PR TITLE
build_falter: change repo to http

### DIFF
--- a/scripts/04-include-falter-feed.sh
+++ b/scripts/04-include-falter-feed.sh
@@ -10,11 +10,13 @@ mkdir -p "$SCRIPTPATH/../embedded-files/etc/opkg/keys"
 URL="https://buildbot.berlin.freifunk.net/buildbot/feed/packagefeed_master.pub"
 curl "$URL" > "$SCRIPTPATH/../embedded-files/etc/opkg/keys/61a078a38408e710"
 
+REPO_HTTP=$(echo $REPO | sed -e 's/https/http/g')
+
 # We inherited $FALTER_REPO_BASE from caller whom exported it.
 printf \
 "
 # add your custom package feeds here
 #
 # src/gz example_feed_name http://www.example.com/path/to/files
-$REPO
+$REPO_HTTP
 " > "$SCRIPTPATH/../embedded-files/etc/opkg/customfeeds.conf"


### PR DESCRIPTION
As opkg enforces signed packages, it should be okay to download
the packages unencrypted via http.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

This PR fixes the issue in recent rc1: opkg wasn't able to download the
packagelists via wget, as there weren't packages installed for that.