### PR TITLE
packagesets: add luci package

### DIFF
--- a/packageset/19.07/backbone.txt
+++ b/packageset/19.07/backbone.txt
@@ -35,6 +35,7 @@ uhttpd
 uhttpd-mod-ubus
 px5g-mbedtls
 libustream-mbedtls
+luci
 luci-mod-falter
 luci-app-olsr
 luci-app-opkg

--- a/packageset/19.07/notunnel.txt
+++ b/packageset/19.07/notunnel.txt
@@ -41,6 +41,7 @@ uhttpd
 uhttpd-mod-ubus
 px5g-mbedtls
 libustream-mbedtls
+luci
 luci-app-ffwizard-falter
 luci-mod-falter
 luci-app-olsr

--- a/packageset/19.07/tunneldigger.txt
+++ b/packageset/19.07/tunneldigger.txt
@@ -40,6 +40,7 @@ uhttpd
 uhttpd-mod-ubus
 #px5g-mbedtls
 #libustream-mbedtls
+luci
 luci-app-ffwizard-falter
 luci-mod-falter
 luci-app-olsr

--- a/packageset/snapshot/backbone.txt
+++ b/packageset/snapshot/backbone.txt
@@ -32,6 +32,7 @@ libiwinfo-lua
 # GUI-basics
 uhttpd
 uhttpd-mod-ubus
+luci
 luci-ssl
 luci-mod-falter
 luci-app-olsr

--- a/packageset/snapshot/notunnel.txt
+++ b/packageset/snapshot/notunnel.txt
@@ -38,6 +38,7 @@ falter-berlin-tunneldigger
 # GUI-basics
 uhttpd
 uhttpd-mod-ubus
+luci
 luci-ssl
 luci-app-ffwizard-falter
 luci-mod-falter

--- a/packageset/snapshot/tunneldigger.txt
+++ b/packageset/snapshot/tunneldigger.txt
@@ -37,6 +37,7 @@ falter-profiles
 # GUI-basics
 uhttpd
 uhttpd-mod-ubus
+luci
 luci-ssl
 luci-app-ffwizard-falter
 luci-mod-falter


### PR DESCRIPTION
The luci package depends on rpcd-mod-rrdns.  This package is missing
and causing DNS looksups on the "Connections" status page to not work.

Adding the luci package also brings in the additional package "luci-proto-ipv6"
which also is not a bad package to have.

Fixes: https://github.com/Freifunk-Spalter/packages/issues/129
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>