### PR TITLE
packagesets: remove unneeded backbone packages

### DIFF
--- a/packageset/19.07/backbone.txt
+++ b/packageset/19.07/backbone.txt
@@ -58,10 +58,6 @@ luci-i18n-statistics-de
 luci-i18n-statistics-en
 luci-i18n-falter-de
 luci-i18n-falter-en
-luci-i18n-ffwizard-falter-de
-luci-i18n-ffwizard-falter-en
-luci-i18n-falter-policyrouting-de
-luci-i18n-falter-policyrouting-en
 
 # OLSR
 olsrd

--- a/packageset/snapshot/backbone.txt
+++ b/packageset/snapshot/backbone.txt
@@ -56,10 +56,6 @@ luci-i18n-statistics-de
 luci-i18n-statistics-en
 luci-i18n-falter-de
 luci-i18n-falter-en
-luci-i18n-ffwizard-falter-de
-luci-i18n-ffwizard-falter-en
-luci-i18n-falter-policyrouting-de
-luci-i18n-falter-policyrouting-en
 
 # OLSR
 olsrd


### PR DESCRIPTION
The following packages are not needed in the backbone images:

luci-i18n-ffwizard-falter-de
luci-i18n-ffwizard-falter-en
luci-i18n-falter-policyrouting-de
luci-i18n-falter-policyrouting-en

simply having these packages cause, at a minimum, the following packages to be installed:

falter-policyrouting
luci-app-falter-policyrouting
luci-app-ffwizard-falter

Fixes: #55
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>