### PR TITLE
Support openwrt 21.02

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you give packageset, release and no target, it will generate all targets of t
 
 If you like to build only one specific router-profile, you *must* give all the arguments before. 
 
-`version` has currently two valid values: `19.07` and `snapshot`.
+`version` has currently these valid values: `19.07`, '21.02' and `snapshot`.
 
 After the buildprocess finished, you will find the images in `firmwares/`.
 

--- a/build_falter
+++ b/build_falter
@@ -10,6 +10,7 @@ source buildconfig.conf
 RELEASES="
     https://downloads.openwrt.org/releases/19.07.5/targets/
     https://downloads.openwrt.org/releases/19.07.6/targets/
+    https://downloads.openwrt.olsr/releases/21.02-SNAPSHOT/targets/
     https://downloads.openwrt.org/snapshots/targets/"
 
 # General variables
@@ -34,7 +35,7 @@ Options:
     give a path to the packageset
 
   -v|--version [VERSION]
-    OpenWrt-release to be used. i.e. '19.07'
+    OpenWrt-release to be used. i.e. '19.07' or '21.02'
 
   -t|--target [TARGET]
     target like 'ath79'
@@ -183,6 +184,8 @@ done
 # specify feed based on openwrt-version
 if [[ "$PARSER_OWT" =~ 19.07 ]]; then # regex-matching. Not portable to sh!
   FALTER_REPO_BASE="$FALTER_REPO_BASE""openwrt-19.07/"
+else if [[ "$PARSER_OWT" =~ 21.02 ]]; then # also regex magic
+  FALTER_REPO_BASE="$FALTER_REPO_BASE""openwrt-21.02/"
 else
   FALTER_REPO_BASE="$FALTER_REPO_BASE""master/"
 fi

--- a/packageset/21.02/backbone.txt
+++ b/packageset/21.02/backbone.txt
@@ -17,6 +17,7 @@ falter-berlin-uhttpd-defaults
 # falter Common
 falter-common
 falter-common-olsr
+falter-berlin-tunneldigger
 
 # Utils
 tcpdump-mini

--- a/packageset/21.02/backbone.txt
+++ b/packageset/21.02/backbone.txt
@@ -1,0 +1,91 @@
+-wpad-mini
+#wpad
+
+# Defaults
+falter-berlin-dhcp-defaults
+falter-berlin-freifunk-defaults
+falter-berlin-network-defaults
+falter-berlin-olsrd-defaults
+falter-berlin-statistics-defaults
+falter-berlin-system-defaults
+falter-berlin-uhttpd-defaults
+
+# Common
+#dnsmasq is already provided via dnsmasq-full
+-dnsmasq
+
+# falter Common
+falter-common
+falter-common-olsr
+
+# Utils
+tcpdump-mini
+mtr
+ip
+iperf3
+tmux
+vnstat
+ethtool
+iwinfo
+libiwinfo-lua
+
+# GUI-basics
+uhttpd
+uhttpd-mod-ubus
+luci
+luci-ssl
+luci-mod-falter
+luci-app-olsr
+luci-app-opkg
+luci-app-olsr-services
+luci-app-falter-owm
+luci-app-falter-owm-ant
+luci-app-falter-owm-cmd
+luci-app-falter-owm-gui
+luci-proto-ppp
+luci-theme-bootstrap
+
+# GUI transalation stuff
+luci-i18n-base-de
+luci-i18n-base-en
+luci-i18n-olsr-de
+luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
+luci-i18n-statistics-de
+luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
+
+# OLSR
+olsrd
+olsrd-mod-arprefresh
+olsrd-mod-dyn-gw
+olsrd-mod-jsoninfo
+olsrd-mod-txtinfo
+olsrd-mod-nameservice
+olsrd-mod-watchdog
+kmod-ipip
+
+# BATMAN
+batctl-full
+-batctl-tiny
+kmod-batman-adv
+alfred
+
+# Statistics
+luci-app-statistics
+collectd
+collectd-mod-dhcpleases
+collectd-mod-interface
+collectd-mod-iwinfo
+collectd-mod-network
+collectd-mod-olsrd
+collectd-mod-rrdtool
+collectd-mod-ping
+collectd-mod-uptime
+collectd-mod-memory

--- a/packageset/21.02/notunnel.txt
+++ b/packageset/21.02/notunnel.txt
@@ -1,0 +1,104 @@
+-wpad-mini
+#wpad
+
+# Defaults
+falter-berlin-dhcp-defaults
+falter-berlin-firewall-defaults
+falter-berlin-freifunk-defaults
+falter-berlin-migration
+falter-berlin-network-defaults
+falter-berlin-olsrd-defaults
+falter-berlin-statistics-defaults
+falter-berlin-system-defaults
+falter-berlin-uhttpd-defaults
+
+# Common
+mtr
+ip
+iperf3
+tmux
+vnstat
+ethtool
+#dnsmasq is already provided via dnsmasq-full
+-dnsmasq
+qos-scripts
+firewall
+iwinfo
+libiwinfo-lua
+tcpdump-mini
+
+# falter Common
+falter-common
+falter-common-olsr
+falter-policyrouting
+falter-profiles
+# allow upgrade from one type to another
+falter-berlin-tunneldigger
+
+# GUI-basics
+uhttpd
+uhttpd-mod-ubus
+luci
+luci-ssl
+luci-app-ffwizard-falter
+luci-mod-falter
+luci-app-olsr
+luci-app-opkg
+luci-app-firewall
+luci-app-olsr-services
+luci-app-falter-owm
+luci-app-falter-owm-ant
+luci-app-falter-owm-cmd
+luci-app-falter-owm-gui
+luci-proto-ppp
+luci-theme-bootstrap
+
+# GUI translation stuff
+luci-i18n-base-de
+luci-i18n-base-en
+luci-i18n-firewall-de
+luci-i18n-firewall-en
+luci-i18n-olsr-de
+luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
+luci-i18n-statistics-de
+luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
+
+# OLSR
+olsrd
+olsrd-mod-arprefresh
+olsrd-mod-dyn-gw
+olsrd-mod-jsoninfo
+olsrd-mod-txtinfo
+olsrd-mod-nameservice
+olsrd-mod-watchdog
+kmod-ipip
+
+# BATMAN
+batctl-full
+-batctl-tiny
+kmod-batman-adv
+alfred
+
+# Uplink
+falter-berlin-uplink-notunnel
+
+# Statistics
+luci-app-statistics
+collectd
+collectd-mod-dhcpleases
+collectd-mod-interface
+collectd-mod-iwinfo
+collectd-mod-network
+collectd-mod-olsrd
+collectd-mod-rrdtool
+collectd-mod-ping
+collectd-mod-uptime
+collectd-mod-memory

--- a/packageset/21.02/tunneldigger.txt
+++ b/packageset/21.02/tunneldigger.txt
@@ -1,0 +1,105 @@
+#-wpad-mini
+#wpad
+
+# Defaults
+falter-berlin-dhcp-defaults
+falter-berlin-firewall-defaults
+falter-berlin-freifunk-defaults
+falter-berlin-migration
+falter-berlin-network-defaults
+falter-berlin-olsrd-defaults
+falter-berlin-statistics-defaults
+falter-berlin-system-defaults
+falter-berlin-uhttpd-defaults
+falter-profiles
+
+# Common
+mtr
+ip
+iperf3
+tmux
+vnstat
+ethtool
+#dnsmasq is already provided via dnsmasq-full
+-dnsmasq
+qos-scripts
+firewall
+iwinfo
+libiwinfo-lua
+tcpdump-mini
+
+# falter Common
+falter-common
+falter-common-olsr
+falter-policyrouting
+falter-profiles
+
+# GUI-basics
+uhttpd
+uhttpd-mod-ubus
+luci
+luci-ssl
+luci-app-ffwizard-falter
+luci-mod-falter
+luci-app-olsr
+luci-app-opkg
+luci-app-firewall
+luci-app-olsr-services
+luci-app-falter-owm
+luci-app-falter-owm-ant
+luci-app-falter-owm-cmd
+luci-app-falter-owm-gui
+luci-proto-ppp
+luci-theme-bootstrap
+
+# GUI transaltion stuff
+luci-i18n-base-de
+luci-i18n-base-en
+luci-i18n-firewall-de
+luci-i18n-firewall-en
+luci-i18n-olsr-de
+luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
+luci-i18n-statistics-de
+luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
+
+# OLSR
+olsrd
+olsrd-mod-arprefresh
+olsrd-mod-dyn-gw
+olsrd-mod-jsoninfo
+olsrd-mod-txtinfo
+olsrd-mod-nameservice
+olsrd-mod-watchdog
+kmod-ipip
+
+# BATMAN
+batctl-full
+-batctl-tiny
+kmod-batman-adv
+alfred
+
+# Uplink
+falter-berlin-uplink-tunnelberlin
+
+# Statistics
+luci-app-statistics
+collectd
+collectd-mod-cpu
+collectd-mod-dhcpleases
+collectd-mod-interface
+collectd-mod-iwinfo
+collectd-mod-load
+collectd-mod-network
+collectd-mod-olsrd
+collectd-mod-rrdtool
+collectd-mod-ping
+collectd-mod-uptime
+collectd-mod-memory


### PR DESCRIPTION
These commits add support for the new openwrt-21.02 branch.  As soon as it is possible to see any content in https://downloads.openwrt.org/releases/21.02-SNAPSHOT/ then this PR will be ready to be merged.