### PR TITLE
packagesets: add falter-berlin-tunneldigger to backbone

### DIFF
--- a/packageset/19.07/backbone.txt
+++ b/packageset/19.07/backbone.txt
@@ -18,6 +18,7 @@ falter-berlin-uhttpd-defaults
 # falter Common
 falter-common
 falter-common-olsr
+falter-berlin-tunneldigger
 
 # Utils
 tcpdump-mini

--- a/packageset/snapshot/backbone.txt
+++ b/packageset/snapshot/backbone.txt
@@ -17,6 +17,7 @@ falter-berlin-uhttpd-defaults
 # falter Common
 falter-common
 falter-common-olsr
+falter-berlin-tunneldigger
 
 # Utils
 tcpdump-mini


### PR DESCRIPTION
add the falter-berlin-tunneldigger to the backbone images so
that after an upgrade, a backbone node which was either using
tunneldigger for the uplink or for a connection to the bbb-vpn
will continue working

Fixes: #57
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>