### PR TITLE
build_falter: fix else if vs elif

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -192,7 +192,7 @@ done
 # specify feed based on openwrt-version
 if [[ "$PARSER_OWT" =~ 19.07 ]]; then # regex-matching. Not portable to sh!
   FALTER_REPO_BASE="$FALTER_REPO_BASE""openwrt-19.07/"
-else if [[ "$PARSER_OWT" =~ 21.02 ]]; then # also regex magic
+elif [[ "$PARSER_OWT" =~ 21.02 ]]; then # also regex magic
   FALTER_REPO_BASE="$FALTER_REPO_BASE""openwrt-21.02/"
 else
   FALTER_REPO_BASE="$FALTER_REPO_BASE""master/"


### PR DESCRIPTION
In #58 I accidentially approved a PR with a minor syntax error.
In bash, there isn't a phrase like 'else if'. Instead, it uses
'elif' keyword for that.

Signed-off-by: Martin Hübner <martin.hubner@web.de>