### PR TITLE
build_falter: select openwrt-version via freifunk-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,45 @@ The script takes five positional arguments.
 ./build_falter [-p packageset] [-v version] [-t target] [-s subtarget] [-r router]
 ```
 
-The packageset is mandatory, the latter ones optional.
-If you just give a packageset, all releases and all targets get built.
+The parameters for packageset, version and target are mandatory. The other ones optional
 
-If you give packageset, release and no target, it will generate all targets of that certain release and so on.
+If you give packageset, release and no subtarget, it will generate all subtargets of that certain target and so on.
 
 If you like to build only one specific router-profile, you *must* give all the arguments before. 
 
-`version` has currently these valid values: `19.07`, '21.02' and `snapshot`.
+`version` takes the falter-version you would like to build. This maps to the feed-directories avaiable at [buildbot](https://firmware.berlin.freifunk.net/feed/).
 
 After the buildprocess finished, you will find the images in `firmwares/`.
 
 
 ## Quickstart: build your own image
 
-Lets assume you'd like to build a stable-release-tunneldigger-image for your GL-AR150 router. To achieve
-that, you should invoke the buildscript in that way:
+Lets assume you'd like to build a stable-release-tunneldigger-image for your GL-AR150 router. To achieve that, you should invoke the buildscript in that way:
 
 ```
-./build_falter -p packageset/19.07/tunneldigger.txt -v 19.07 -t ath79 -s generic -r glinet_gl-ar150
+./build_falter -p packageset/19.07/tunneldigger.txt -v 1.1.1 ath79 -s generic -r glinet_gl-ar150
 ```
-If you are more comfortable in memorizing it that way, you can also use long arguments:
+If you are more comfortable in memorizing it that way, you can use long arguments:
 ```
-./build_falter --packageset packageset/19.07/tunneldigger.txt --version 19.07 --target ath79 --sub-target generic -router glinet_gl-ar150
+./build_falter --packageset packageset/19.07/tunneldigger.txt --version 1.1.1 --target ath79 --sub-target generic -router glinet_gl-ar150
+```
+
+### Find your routers profile
+
+If you don't know the profile name for your router, you should use `-l` to find it. That option will show you a list of all routers with there profiles. Pick the profile-name there and give it to the script with the `-r` parameter.
+
+```
+./build_falter -p packageset/19.07/tunneldigger.txt -v 1.1.1-snapshot -t ath79 -s generic -l
+```
+In the router list you will find something similar like that:
+```
+glinet_gl-ar150:
+    GL.iNet GL-AR150
+    SupportedDevices: glinet,gl-ar150 gl-ar150
+```
+The profile name is at the first line. Omit the colon:
+```
+./build_falter -p packageset/19.07/tunneldigger.txt -v 1.1.1-snapshot -t ath79 -s generic -r glinet_gl-ar150
 ```
 
 ## Use builter with buildbot

--- a/build_falter
+++ b/build_falter
@@ -7,6 +7,7 @@
 # get some build-config
 source buildconfig.conf
 
+RELEASE_LINK_BASE="https://downloads.openwrt.org/releases/"
 RELEASES="
     https://downloads.openwrt.org/releases/19.07.5/targets/
     https://downloads.openwrt.org/releases/19.07.6/targets/
@@ -34,7 +35,8 @@ Options:
     give a path to the packageset
 
   -v|--version [VERSION]
-    OpenWrt-release to be used. i.e. '19.07' or '21.02'
+    Falter-release to be used. i.e. '1.1.0' or '1.1.1-snapshot', etc.
+    Maps directly to the directories at https://firmware.berlin.freifunk.net/feed/
 
   -t|--target [TARGET]
     target like 'ath79'
@@ -104,8 +106,8 @@ while :; do
 
     v* | -version)
         if [ "$2" ]; then
-            echo "OpenWrt-version is: $2"
-            PARSER_OWT="$2"
+            echo "Falter-version is: $2"
+            PARSER_FALTER_VERSION="$2"
             shift
         else
             echo "Version parameters incomplete!" >&2
@@ -187,15 +189,6 @@ while :; do
     fi
 done
 
-# specify feed based on openwrt-version
-if [[ "$PARSER_OWT" =~ 19.07 ]]; then # regex-matching. Not portable to sh!
-    FALTER_REPO_BASE="$FALTER_REPO_BASE""openwrt-19.07/"
-elif [[ "$PARSER_OWT" =~ 21.02 ]]; then # also regex magic
-    FALTER_REPO_BASE="$FALTER_REPO_BASE""openwrt-21.02/"
-else
-    FALTER_REPO_BASE="$FALTER_REPO_BASE""master/"
-fi
-
 # check for dependencies.
 SCRIPT_DEPENDS="awk curl gawk grep git gettext python3 rsync sed unzip wget"
 for DEP in $SCRIPT_DEPENDS; do
@@ -206,9 +199,28 @@ for DEP in $SCRIPT_DEPENDS; do
     fi
 done
 
+# repository derives directly from the falter-version. Download freifunk_release
+# file and determine openwrt-version by its variables
+BASE_URL=$(echo $FALTER_REPO_BASE | cut -d' ' -f 3)
+FEEDURL="$BASE_URL$PARSER_FALTER_VERSION/packages/mips_24kc/falter/"
+COMMONFILEURL=$FEEDURL$(curl -s ${FEEDURL}/Packages | sed -n '/falter-common$/,/^$/p' | awk '{if(/Filename: /) print $2}')
+TMP=$(curl -s $COMMONFILEURL | tar xzOf - ./data.tar.gz | tar xzOf - ./etc/freifunk_release)
+eval $TMP
+
 #################
 #   FUNCTIONS   #
 #################
+
+function derive_packagelist_version {
+    # OpenWrt-Version from freifunk-release file could be something like
+    # '19.07-SNAPSHOT'. But we have only packagelists for 19.07... Solve that.
+    regex="^[0-9][0-9].[0-9][0-9]"
+    if [[ $1 =~ $regex ]]; then
+        echo $(echo $1 | cut -c 1-5)
+    else
+        echo "snapshot"
+    fi
+}
 
 function read_packageset {
     local PACKAGE_SET_PATH=$1
@@ -260,14 +272,10 @@ function generate_embedded_files {
     # Get the FREIFUNK_RELEASE variable from the falter feed
     # located in the falter-common package.
     [ "snapshot" == $FALTERBRANCH ] && FALTERBRANCH="master"
-    [ $FALTERBRANCH != "master" ] && FALTERBRANCH="openwrt-$FALTERBRANCH"
-    local FEEDURL=$(echo $REPO | cut -d ' ' -f 3)
-    local COMMONFILEURL=$FEEDURL"/"$(curl -s ${FEEDURL}/Packages | sed -n '/falter-common$/,/^$/p' | awk '{if(/Filename: /) print $2}')
-    local TMP=$(curl -s $COMMONFILEURL | tar xzOf - ./data.tar.gz | tar xzOf - ./etc/freifunk_release)
-    eval $TMP
+    [ $FALTERBRANCH != "master" ] && FALTERBRANCH="openwrt-$PARSER_OWT"
 
     ../../scripts/01-generate_banner.sh $FREIFUNK_RELEASE $NICKNAME $TARGET $SUBTARGET $FREIFUNK_REVISION
-    ../../scripts/03-luci-footer.sh $FREIFUNK_RELEASE $NICKNAME $TARGET $SUBTARGET $FREIFUNK_OPENWRT_BASE $FREIFUNK_REVISION
+    ../../scripts/03-luci-footer.sh $FREIFUNK_RELEASE $NICKNAME $TARGET $SUBTARGET $FALTERBRANCH $FREIFUNK_REVISION
     export REPO # export repo line to inject into images. contains whitespace...
     ../../scripts/04-include-falter-feed.sh
 }
@@ -319,7 +327,7 @@ function start_build {
     INSTR_SET=$(grep "openwrt_base" repositories.conf | awk -F'/' "{print \$$ispos}")
     echo "selected instruction set: $INSTR_SET"
 
-    REPO="$FALTER_REPO_BASE/packages/$INSTR_SET/falter"
+    REPO="$FALTER_REPO_BASE/$PARSER_FALTER_VERSION/packages/$INSTR_SET/falter"
     echo "injecting repo line: $REPO"
     echo "$REPO" >>repositories.conf
 
@@ -367,6 +375,8 @@ function start_build {
 #    MAIN    #
 ##############
 
+PARSER_OWT=$(derive_packagelist_version $FREIFUNK_OPENWRT_BASE)
+
 if [ "$PARSER_PACKAGESET" == "all" ]; then
     # build all imageflavours. For this, get paths of packagesets
     # fetch paths of packagelists (depends on openwrt-version). If not unique, chose most recent version of possibilities.
@@ -403,8 +413,7 @@ if [ -z "$CONF_RELEASE" ] && [ -z "$CONF_TARGET" ]; then
     exit
 elif [ -z "$CONF_TARGET" ]; then
     # build one release for all targets
-    # fetch release-link. in case there is more than one, fetch recent release.
-    RELEASE_LINK=$(echo "$RELEASES" | tr ' ' '\n' | grep "$CONF_RELEASE" | tail -n 1)
+    RELEASE_LINK="$RELEASE_LINK_BASE""$FREIFUNK_OPENWRT_BASE""/targets/"
     for target in $(fetch_subdirs "$RELEASE_LINK"); do
         for subtarget in $(fetch_subdirs $RELEASE_LINK$target); do
             imagebuilder=$(fetch_subdirs $RELEASE_LINK$target$subtarget | grep imagebuilder)
@@ -414,7 +423,7 @@ elif [ -z "$CONF_TARGET" ]; then
     exit
 else
     # there was given a release and a target
-    RELEASE_LINK=$(echo "$RELEASES" | tr ' ' '\n' | grep "$CONF_RELEASE" | tail -n 1)
+    RELEASE_LINK="$RELEASE_LINK_BASE""$FREIFUNK_OPENWRT_BASE""/targets/"
     # if there was defined a subtarget and option device, only build that.
     if [ -n "$CONF_SUBTARGET" ]; then
         # build directly that subtarget. if requested, for all image types.


### PR DESCRIPTION
In the freifunk_release file of each feed there are variables which
define the OpenWrt-Version the feed is intended for. This commit
introduces changes to use that OpenWrt-Verison mentioned there.

The option `-v` now encodes which falter-version to use. The version
maps directly to the package feed at the buildbot.

This fixes #63.

Signed-off-by: Martin Hübner <martin.hubner@web.de>