### PR TITLE
Work around for kernel2minor path length limitation

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -306,6 +306,7 @@ function start_build {
     cd $FOLDERNAME
     # patch json-info, so that it will contain every image, not just the last one
     cp -f ../../patches/json_overview_image_info.py scripts/json_overview_image_info.py
+    patch -p2 -i ../../patches/workaround-kernel2minor-path-length-limitation.patch
 
     if [ "$PARSER_LIST_ROUTERS" == "y" ]; then
         # if ask for, show avaiable router-profiles and quit

--- a/patches/workaround-kernel2minor-path-length-limitation.patch
+++ b/patches/workaround-kernel2minor-path-length-limitation.patch
@@ -1,0 +1,15 @@
+--- a/openwrt-imagebuilder-21.02-SNAPSHOT-ipq40xx-mikrotik.Linux-x86_64/include/image-commands.mk	2021-05-05 10:22:36.000000000 +0200
++++ b/openwrt-imagebuilder-21.02-SNAPSHOT-ipq40xx-mikrotik.Linux-x86_64/include/image-commands.mk	2021-05-05 10:26:49.000000000 +0200
+@@ -240,8 +240,10 @@
+ endef
+ 
+ define Build/kernel2minor
+-	kernel2minor -k $@ -r $@.new $(1)
+-	mv $@.new $@
++	$(eval temp_file := $(shell mktemp))
++	cp $@ $(temp_file)
++	kernel2minor -k $(temp_file) -r /tmp/bar $(1)
++	mv $(temp_file) $@
+ endef
+ 
+ define Build/kernel-bin


### PR DESCRIPTION
Patch to work around kernel2minor path length limitation.
This allows building e.g. `mikrotik_sxtsq-5-ac` which uses kernel2minor with version `1.2.0-snapshot` which leads to paths longer than 250 chars.

Note that there is a related issue upstream but it has not been active for a while now: https://github.com/openwrt/openwrt/pull/3262.