### PR TITLE
correct workaround-kernel2minor-path-length-limitation.patch

### DIFF
--- a/patches/workaround-kernel2minor-path-length-limitation.patch
+++ b/patches/workaround-kernel2minor-path-length-limitation.patch
@@ -1,6 +1,6 @@
 --- a/openwrt-imagebuilder-21.02-SNAPSHOT-ipq40xx-mikrotik.Linux-x86_64/include/image-commands.mk	2021-05-05 10:22:36.000000000 +0200
 +++ b/openwrt-imagebuilder-21.02-SNAPSHOT-ipq40xx-mikrotik.Linux-x86_64/include/image-commands.mk	2021-05-05 10:26:49.000000000 +0200
-@@ -240,8 +240,10 @@
+@@ -272,8 +272,11 @@
  endef
  
  define Build/kernel2minor
@@ -8,8 +8,9 @@
 -	mv $@.new $@
 +	$(eval temp_file := $(shell mktemp))
 +	cp $@ $(temp_file)
-+	kernel2minor -k $(temp_file) -r /tmp/bar $(1)
-+	mv $(temp_file) $@
++	kernel2minor -k $(temp_file) -r $(temp_file).new $(1)
++	mv $(temp_file).new $@
++	rm -f $(temp_file)
  endef
  
  define Build/kernel-bin


### PR DESCRIPTION
I mixed switches up in #70. Here is a simpler/uglier patch that is easy to understand and does work as expected:
- kernel2minor will not fail
- the output image will be in the right format

Tested with `./build_falter -p packageset/21.02/tunneldigger.txt -v 1.2.0-snapshot -t ipq40xx -s mikrotik -r mikrotik_sxtsq-5-ac
` and made sure that
- there were no error messages from kernel2minor any more and
- that the output (`firmwares/targets/ipq40xx/mikrotik/openwrt-21.02-snapshot-r16065-10a535a90c-freifunk-falter-1.2.0-snapshot-ipq40xx-mikrotik-mikrotik_sxtsq-5-ac-squashfs-sysupgrade.bin`) was in the right format.