### PR TITLE
Ensure keys/ directory exists

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -352,6 +352,7 @@ function start_build {
     # the hexadecimal number represents the fringerprint of the key. Refer to third section of https://openwrt.org/docs/guide-user/security/keygen#generate_usign_key_pair
     local URL="https://firmware.berlin.freifunk.net/feed/packagefeed_master.pub"
     echo "loading package-feed key from $URL"
+    mkdir -p keys
     curl -L "$URL" > keys/61a078a38408e710
     # check, if we really got a key
     grep "untrusted comment:" keys/61a078a38408e710 > /dev/null


### PR DESCRIPTION
Some imagebuilder tarballs do not contain a `keys/` directory e.g. `openwrt-imagebuilder-19.07.7-ar71xx-generic.Linux-x86_64.tar.xz` (2021-02-17, `sha1:45492dab1f8e836c4a827d21f9058dbdf700679f`) that gets downloaded when running `./build_falter -p packageset/19.07/notunnel.txt --version 1.1.1 -t ar71xx -s generic -r ubnt-uap-pro`.
This PR creates it as a workaround, with `-p` so that the `mkdir` invocation does not fail should the directory already exist.

Tested with:
- `./build_falter -p packageset/19.07/notunnel.txt --version 1.1.1 -t ar71xx -s generic -r ubnt-uap-pro` (fails withtout patch, works with patch)
- `./build_falter -p packageset/21.02/tunneldigger.txt -v 1.2.0-snapshot -t ipq40xx -s mikrotik -r mikrotik_sxtsq-5-ac` (works with or without patch)