### PR TITLE
packageset/20.02: remove olsrd_watchdog from lists

### DIFF
--- a/packageset/21.02/backbone.txt
+++ b/packageset/21.02/backbone.txt
@@ -70,7 +70,6 @@ olsrd-mod-dyn-gw
 olsrd-mod-jsoninfo
 olsrd-mod-txtinfo
 olsrd-mod-nameservice
-olsrd-mod-watchdog
 kmod-ipip
 
 # BATMAN

--- a/packageset/21.02/notunnel.txt
+++ b/packageset/21.02/notunnel.txt
@@ -79,7 +79,6 @@ olsrd-mod-dyn-gw
 olsrd-mod-jsoninfo
 olsrd-mod-txtinfo
 olsrd-mod-nameservice
-olsrd-mod-watchdog
 kmod-ipip
 
 # BATMAN

--- a/packageset/21.02/tunneldigger.txt
+++ b/packageset/21.02/tunneldigger.txt
@@ -78,7 +78,6 @@ olsrd-mod-dyn-gw
 olsrd-mod-jsoninfo
 olsrd-mod-txtinfo
 olsrd-mod-nameservice
-olsrd-mod-watchdog
 kmod-ipip
 
 # BATMAN


### PR DESCRIPTION
Now that procd handles olsrd[6], the olsrd_watchdog plugin is no
longer needed.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>